### PR TITLE
Save polarPriceId during subscription update AND select latest subscription 

### DIFF
--- a/convex/subscriptions.ts
+++ b/convex/subscriptions.ts
@@ -185,7 +185,7 @@ export const checkUserSubscriptionStatus = query({
       }
       tokenIdentifier = identity.subject;
     }
-
+    
     const user = await ctx.db
       .query("users")
       .withIndex("by_token", (q) => q.eq("tokenIdentifier", tokenIdentifier))
@@ -194,10 +194,11 @@ export const checkUserSubscriptionStatus = query({
     if (!user) {
       return { hasActiveSubscription: false };
     }
-
+    
     const subscription = await ctx.db
       .query("subscriptions")
       .withIndex("userId", (q) => q.eq("userId", user.tokenIdentifier))
+      .order("desc")  // Order by createdAt in descending order
       .first();
 
     const hasActiveSubscription = subscription?.status === "active";
@@ -234,6 +235,7 @@ export const checkUserSubscriptionStatusByClerkId = query({
     const subscription = await ctx.db
       .query("subscriptions")
       .withIndex("userId", (q) => q.eq("userId", user.tokenIdentifier))
+      .order("desc")  // Order by createdAt in descending order
       .first();
 
     const hasActiveSubscription = subscription?.status === "active";
@@ -261,6 +263,7 @@ export const fetchUserSubscription = query({
     const subscription = await ctx.db
       .query("subscriptions")
       .withIndex("userId", (q) => q.eq("userId", user.tokenIdentifier))
+      .order("desc")  // Order by createdAt in descending order
       .first();
 
     return subscription;
@@ -328,6 +331,7 @@ export const handleWebhookEvent = mutation({
 
         if (existingSub) {
           await ctx.db.patch(existingSub._id, {
+            polarPriceId: args.body.data.price_id,
             amount: args.body.data.amount,
             status: args.body.data.status,
             currentPeriodStart: new Date(


### PR DESCRIPTION
# Fix Subscription Price ID Handling and Update Logic

## Problem
When a subscription is updated in Polar, the `polarPriceId` in our database wasn't being updated, causing a mismatch between the actual subscription plan and what's displayed to users. This resulted in the warning message "You have an active subscription that's not shown above" being incorrectly displayed to users.

## Changes Made
1. Updated subscription handling in webhook events:
   ```typescript
   case "subscription.updated":
     await ctx.db.patch(existingSub._id, {
       amount: args.body.data.amount,
       status: args.body.data.status,
       // Added polarPriceId update
       polarPriceId: args.body.data.price_id,
       // ... other fields
     });
   ```

2. Improved subscription querying to always get the latest subscription:
   ```typescript
   const subscription = await ctx.db
     .query("subscriptions")
     .withIndex("userId", (q) => q.eq("userId", user.tokenIdentifier))
     .order("desc")  // Order by createdAt in descending order
     .first();
   ```
