### PR TITLE
Fix/subscription metadata priceid remove

### DIFF
--- a/convex/subscriptions.ts
+++ b/convex/subscriptions.ts
@@ -185,7 +185,7 @@ export const checkUserSubscriptionStatus = query({
       }
       tokenIdentifier = identity.subject;
     }
-
+    
     const user = await ctx.db
       .query("users")
       .withIndex("by_token", (q) => q.eq("tokenIdentifier", tokenIdentifier))
@@ -194,10 +194,11 @@ export const checkUserSubscriptionStatus = query({
     if (!user) {
       return { hasActiveSubscription: false };
     }
-
+    
     const subscription = await ctx.db
       .query("subscriptions")
       .withIndex("userId", (q) => q.eq("userId", user.tokenIdentifier))
+      .order("desc")  // Order by createdAt in descending order
       .first();
 
     const hasActiveSubscription = subscription?.status === "active";
@@ -234,6 +235,7 @@ export const checkUserSubscriptionStatusByClerkId = query({
     const subscription = await ctx.db
       .query("subscriptions")
       .withIndex("userId", (q) => q.eq("userId", user.tokenIdentifier))
+      .order("desc")  // Order by createdAt in descending order
       .first();
 
     const hasActiveSubscription = subscription?.status === "active";
@@ -261,6 +263,7 @@ export const fetchUserSubscription = query({
     const subscription = await ctx.db
       .query("subscriptions")
       .withIndex("userId", (q) => q.eq("userId", user.tokenIdentifier))
+      .order("desc")  // Order by createdAt in descending order
       .first();
 
     return subscription;
@@ -328,6 +331,7 @@ export const handleWebhookEvent = mutation({
 
         if (existingSub) {
           await ctx.db.patch(existingSub._id, {
+            polarPriceId: args.body.data.price_id,
             amount: args.body.data.amount,
             status: args.body.data.status,
             currentPeriodStart: new Date(

--- a/convex/subscriptions.ts
+++ b/convex/subscriptions.ts
@@ -51,7 +51,6 @@ const createCheckout = async ({
     customerEmail: customerEmail,
     metadata: {
       ...metadata,
-      priceId: productPriceId,
     },
   };
 


### PR DESCRIPTION
fix inconsistent priceId value in metadata stored in Polar and Convex. priceId is not updated after a user changes the subscription creating confusion.

Changes Summary:

Checkout Creation (lines 52-54):

REMOVED: priceId: productPriceId, from the metadata object
RESULT: Metadata now only contains userId when creating Polar checkouts
Impact:

Polar subscriptions: Will only store userId in metadata (no priceId)
Convex subscriptions: Will only store userId in metadata (no priceId)
Price tracking: Still works via the polarPriceId field in the subscription record
User linking: Preserved via userId in metadata for webhook processing